### PR TITLE
Update crane to 0.19.1

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -73,7 +73,7 @@ function install_crane() {
   esac
 
   # install crane
-  curl -L https://github.com/google/go-containerregistry/releases/download/v0.11.0/${file} |tar zx -C /tmp
+  curl -L https://github.com/google/go-containerregistry/releases/download/v0.19.1/${file} |tar zx -C /tmp
   mv /tmp/crane .
   chmod +x crane
 }


### PR DESCRIPTION
See: https://github.com/google/go-containerregistry/releases/