### PR TITLE
Install mariadb-connector-c-dev

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk add --update --no-cache mysql-client
+RUN apk add --update --no-cache mysql-client mariadb-connector-c-dev
 
 ENTRYPOINT ["/usr/bin/mysql"]
 CMD ["--help"]


### PR DESCRIPTION
Since MySQL 8.0.4 the default authentication plugin was changed to `caching_sha2_password`

Without the plugin, when connecting to a MySQL server with default settings, it will emit the following error:

```
ERROR 1045 (28000): Plugin caching_sha2_password could not be loaded: Error loading shared library /usr/lib/mariadb/plugin/caching_sha2_password.so: No such file or directory
```