### PR TITLE
[MySQL] use mariadb-connector-c instead of dev package

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk add --update --no-cache mysql-client mariadb-connector-c-dev
+RUN apk add --update --no-cache mysql-client mariadb-connector-c
 
 ENTRYPOINT ["/usr/bin/mysql"]
 CMD ["--help"]


### PR DESCRIPTION
Per #14 we don't need the dev package