### PR TITLE
ansible: Add `py3-passlib` to image

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-RUN apk add --update --no-cache ansible bash openssh sshpass rsync
+RUN apk add --update --no-cache ansible bash openssh sshpass rsync py3-passlib
 
 ENTRYPOINT []
 CMD ["ansible", "--help"]


### PR DESCRIPTION
Without it, ansible won't work when playbooks invoke `password_hash`.