### PR TITLE
Use the system root certificate by default

### DIFF
--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -2,4 +2,7 @@ FROM alpine
 
 RUN apk add --update --no-cache postgresql-client
 
+# By default Postgres looks for a root cert in /root/.postgresql/root.crt which doesn't exist within this container
+ENV PGSSLROOTCERT=system
+
 ENTRYPOINT ["/usr/bin/psql"]


### PR DESCRIPTION
When connecting to an SSL-enabled postgres instance clients need to use `sslmode=verify-full` (or `verify-ca`) to actually validate the server's SSL certificate. However doing so with this container hits an error:

```
$ docker run -i --rm -e PGPASSWORD -e PGSSLMODE=verify-full alpine/psql:18.1 -h postgres.example.com -U user db
psql: error: connection to server at "postgres.example.com" (123.45.67.89), port 5432 failed: root certificate file "/root/.postgresql/root.crt" does not exist
Either provide the file, use the system's trusted roots with sslrootcert=system, or change sslmode to disable server certificate verification.
```

Given that this `root.crt` file has not been added to this container, I think the appropriate fix is to use the `system` roots by default instead. The workaround is for callers to manually set `-e PGSSLROOTCERT=system whenever using `-e PGSSLMODE=verify-full`, but that seems tediously verbose given that the existing default will not ever work.