### PR TITLE
Revert "Use the system root certificate by default"

### DIFF
--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -2,7 +2,4 @@ FROM alpine
 
 RUN apk add --update --no-cache postgresql-client
 
-# By default Postgres looks for a root cert in /root/.postgresql/root.crt which doesn't exist within this container
-ENV PGSSLROOTCERT=system
-
 ENTRYPOINT ["/usr/bin/psql"]


### PR DESCRIPTION
Reverts alpine-docker/multi-arch-docker-images#36 - @arban reports this introduces a regression.