### PR TITLE
docs: Include repository links in all README files

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -4,8 +4,9 @@
 - small image size on alpine
 - image tag is ansible core version
 
-### source of Dockerfile
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/ansible/Dockerfile
 
 ### Daily CI build logs

--- a/asma/README.md
+++ b/asma/README.md
@@ -1,7 +1,8 @@
 aws-secretsmanager-agent - The AWS Secrets Manager Agent is a local HTTP service that you can install and use in your compute environments to read secrets from Secrets Manager and cache them in memory.
 
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/asma/Dockerfile
 
 ### Daily CI build logs

--- a/bruno/README.md
+++ b/bruno/README.md
@@ -8,9 +8,10 @@ Auto-trigger docker build for [bruno cli](https://github.com/usebruno/bruno) whe
 
 [![DockerHub Badge](http://dockeri.co/image/alpine/bruno)](https://hub.docker.com/r/alpine/bruno/)
 
-### Github Repo
+### Repository
 
-https://github.com/alpine-docker/multi-arch-docker-images/tree/master/bruno
+The source for this image is available on GitHub:
+https://github.com/alpine-docker/multi-arch-docker-images/blob/master/bruno/Dockerfile
 
 ### Daily CI build logs
 

--- a/curl/README.md
+++ b/curl/README.md
@@ -8,6 +8,11 @@ NOTES: the original upstream https://github.com/appropriate/docker-curl is in re
 
 This repo will manage with latest alpine version, and passed trivy scan.
 
+## Repository
+
+The source for this image is available on GitHub:
+https://github.com/alpine-docker/multi-arch-docker-images/blob/master/curl/Dockerfile
+
 ## Usage
 
 * with `docker run`

--- a/flake8/README.md
+++ b/flake8/README.md
@@ -4,8 +4,9 @@ Auto-trigger docker build for [flake8](http://flake8.pycqa.org/) when new releas
 
 Multi-arch supported (linux/arm/v7,linux/arm64/v8,linux/arm/v6,linux/amd64,linux/ppc64le,linux/s390x)
 
-### Repo:
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/flake8/Dockerfile
 
 ### Daily build logs:

--- a/httpie/README.md
+++ b/httpie/README.md
@@ -16,9 +16,10 @@ This feature was added on June 25th, 2023.
 - I only provide support for the `linux/amd64` platform since I don't have an environment to test other platforms. If you encounter any issues with other architectures, please submit a pull request to address them.
 - There will be no difference when using the docker pull and docker run commands with other architectures; you can use them as you normally would. For instance, if you need to pull an image for the ARM architecture (such as the new Mac M1 chip), you can run `docker pull alpine/httpie:3.2.2` to directly obtain the image.
 
-### Github Repo
+### Repository
 
-https://github.com/alpine-docker/multi-arch-docker-images/tree/master/httpie
+The source for this image is available on GitHub:
+https://github.com/alpine-docker/multi-arch-docker-images/blob/master/httpie/Dockerfile
 
 ### Daily CI build logs
 

--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -6,6 +6,11 @@ Alpine-based image with kubectl
 
 This image provides a minimal Alpine Linux container with kubectl installed, supporting multiple architectures.
 
+## Repository
+
+The source for this image is available on GitHub:
+https://github.com/alpine-docker/multi-arch-docker-images/blob/master/kubectl/Dockerfile
+
 ## Usage
 
 * with `docker run`

--- a/links/README.md
+++ b/links/README.md
@@ -1,5 +1,6 @@
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/links/Dockerfile
 
 ### Daily CI build logs

--- a/lynx/README.md
+++ b/lynx/README.md
@@ -1,5 +1,6 @@
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/lynx/Dockerfile
 
 ### Daily CI build logs

--- a/mkcert/README.md
+++ b/mkcert/README.md
@@ -1,7 +1,8 @@
 mkcert - A simple zero-config tool to make locally trusted development certificates with any names you'd like.
 
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/mkcert/Dockerfile
 
 ### Daily CI build logs

--- a/mongosh/README.md
+++ b/mongosh/README.md
@@ -1,7 +1,8 @@
 mongosh — The Mongo Command-Line Client
 
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/mongosh/Dockerfile
 
 ### Daily CI build logs

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -1,7 +1,8 @@
 mysql — The MySQL Command-Line Client
 
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/mysql/Dockerfile
 
 ### Daily CI build logs

--- a/openssl/README.md
+++ b/openssl/README.md
@@ -4,9 +4,10 @@ A useful simple openssl container running in alpine Linux
 
 [![DockerHub Badge](http://dockeri.co/image/alpine/openssl)](https://hub.docker.com/r/alpine/openssl/)
 
-### Github Repo
+### Repository
 
-https://github.com/alpine-docker/multi-arch-docker-images/blob/master/openssl
+The source for this image is available on GitHub:
+https://github.com/alpine-docker/multi-arch-docker-images/blob/master/openssl/Dockerfile
 
 ### CI build logs
 

--- a/psql/README.md
+++ b/psql/README.md
@@ -1,7 +1,8 @@
 psql — The PostgreSQL Command-Line Client
 
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/psql/Dockerfile
 
 ### Daily CI build logs

--- a/semver/README.md
+++ b/semver/README.md
@@ -2,8 +2,9 @@
 
 Docker image with [Semantic Versioning 2.0.0](https://semver.org/)
 
-### Github Repo
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/semver/Dockerfile
 
 ### Docker image tags

--- a/snmpsimulator/README.md
+++ b/snmpsimulator/README.md
@@ -1,7 +1,8 @@
-snmp emulator 
+snmp emulator
 
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/snmpsimulator/Dockerfile
 
 ### Daily CI build logs

--- a/socat/README.md
+++ b/socat/README.md
@@ -12,9 +12,10 @@ Weekly auto-trigger docker build for [socat](https://pkgs.alpinelinux.org/packag
 
 <img width="1188" alt="image" src="https://user-images.githubusercontent.com/8954908/162615860-c8ddce4d-d6bf-423c-adb3-e23a358b77d9.png">
 
-### Repo:
+### Repository
 
-https://github.com/alpine-docker/multi-arch-docker-images/tree/master/socat
+The source for this image is available on GitHub:
+https://github.com/alpine-docker/multi-arch-docker-images/blob/master/socat/Dockerfile
 
 ### scheduled build logs:
 

--- a/sqlite/README.md
+++ b/sqlite/README.md
@@ -1,7 +1,8 @@
 sqlite
 
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/sqlite/Dockerfile
 
 ### Daily CI build logs
@@ -10,7 +11,7 @@ N/A
 
 ### Docker image tags
 
-https://hub.docker.com/repository/docker/alpine/mysql/tags
+https://hub.docker.com/repository/docker/alpine/sqlite/tags
 
 ### quick start
 

--- a/trivy/README.md
+++ b/trivy/README.md
@@ -1,7 +1,8 @@
 trivy — Find vulnerabilities, misconfigurations, secrets, SBOM in containers, Kubernetes, code repositories, clouds and more
 
-### source of `Dockerfile`
+### Repository
 
+The source for this image is available on GitHub:
 https://github.com/alpine-docker/multi-arch-docker-images/blob/master/trivy/Dockerfile
 
 ### Daily CI build logs

--- a/xml/README.md
+++ b/xml/README.md
@@ -1,8 +1,9 @@
 # xml parser
 
-### Github Repo
+### Repository
 
-https://github.com/alpine-docker/multi-arch-docker-images/xml
+The source for this image is available on GitHub:
+https://github.com/alpine-docker/multi-arch-docker-images/blob/master/xml/Dockerfile
 
 ### Daily Travis CI build logs
 


### PR DESCRIPTION
Fixes #10. This commit adds a link in each README that points to the corresponding Dockerfile on GitHub. This will enable Docker Hub users to find the source code for each image.